### PR TITLE
Fix treecat errors outside git repos

### DIFF
--- a/scripts/treecat
+++ b/scripts/treecat
@@ -15,6 +15,14 @@
 #
 
 # Array to store additional ignore paths specified via the -i flag
+set -euo pipefail
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Error: '$1' not found" >&2; exit 1; }; }
+
+need tree
+need git
+need realpath
+
 EXTRA_IGNORES=()
 
 # Parse command-line options: -i for additional paths to ignore
@@ -41,8 +49,12 @@ BASE_DIR="${1:-.}"
 # Function that uses "git check-ignore" to determine if a file or directory should be ignored
 is_ignored() {
   local relative_path="$1"
-  git -C "$BASE_DIR" check-ignore -q "$relative_path"
-  return $?
+  if git -C "$BASE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$BASE_DIR" check-ignore -q "$relative_path"
+    return $?
+  else
+    return 1
+  fi
 }
 
 # Function to traverse the directory and process each entry


### PR DESCRIPTION
## Summary
- add dependency checks and `set -euo pipefail`
- skip `.gitignore` checks when directory isn't under git

## Testing
- `bash -n scripts/treecat`

------
https://chatgpt.com/codex/tasks/task_e_6884aaad5e0c8326a2bf8d008613e022