### PR TITLE
docs: add ansible section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The goal of this project is to create a **reproducible, declarative, and automat
   - `secrets.yaml`: The `sops`-encrypted secrets file.
 - `/config/`: Non-Nix configuration files, such as for `nvim`.
 - `/scripts/`: Miscellaneous helper scripts.
+- `/ansible/`: Ansible playbooks and roles for deploying monitoring exporters.
 
 ## Getting Started
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,48 @@
+# Ansible Playbooks
+
+This directory automates the deployment of monitoring exporters and related tooling with [Ansible](https://www.ansible.com/).
+
+## Table of Contents
+
+- [Structure](#structure)
+- [Usage](#usage)
+  - [Deploy exporters](#deploy-exporters)
+  - [Remove exporters](#remove-exporters)
+
+## Structure
+
+- `ansible.cfg`: Local Ansible settings and role paths.
+- `Justfile`: Wrapper commands around `ansible-playbook`.
+- `playbooks/`: Playbooks to install or remove exporters.
+- `roles/`: Role implementations for each exporter.
+- `collections/`: Vendored Ansible collections.
+
+## Usage
+
+### Deploy exporters
+
+Run the Just recipes with a comma-separated list of hosts:
+
+```bash
+# Install node_exporter on two machines
+just node_exporter HOSTS=host1,host2 USER=rus
+
+# Install pve_exporter (requires an API token)
+just pve_exporter HOSTS=pve1 TOKEN=token USER=root
+
+# Install blackbox_exporter with a custom config path
+just blackbox_exporter HOSTS=host1 CONFIG=/etc/blackbox.yml
+```
+
+### Remove exporters
+
+```bash
+# Remove node_exporter
+just remove_node_exporter HOSTS=host1 USER=rus
+
+# Remove pve_exporter
+just remove_pve_exporter HOSTS=pve1 USER=root
+
+# Remove blackbox_exporter
+just remove_blackbox_exporter HOSTS=host1 USER=rus
+```


### PR DESCRIPTION
## Summary
- document Ansible playbooks for deploying monitoring exporters
- reference the Ansible directory in the root README

## Testing
- `just nix_check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68973a7d741883268a02951ee373e3ee