### PR TITLE
feat: update language servers and formatters

### DIFF
--- a/nix/home/rus/home.nix
+++ b/nix/home/rus/home.nix
@@ -70,7 +70,6 @@ let
     python313Packages.pylatexenc
     lua51Packages.luarocks-nix
     lua51Packages.tiktoken_core
-    lua51Packages.lua
 
     # Build Tools
     cmake
@@ -144,8 +143,17 @@ let
     marksman
     nil
     nodePackages.vscode-langservers-extracted
-    nodePackages.yaml-language-server
     tree-sitter
+    lua-language-server
+    terraform-ls
+    gopls
+    vtsls
+    pyright
+    helm-ls
+    yaml-language-server
+    ansible-language-server
+    taplo
+    ruff
     # Formatters & Linters
     alejandra
     ast-grep


### PR DESCRIPTION
## Summary
- Add comprehensive language server support: lua-language-server, terraform-ls, gopls, vtsls, pyright, helm-ls, yaml-language-server, ansible-language-server, taplo, and ruff
- Remove duplicate lua package and yaml-language-server from nodePackages
- Reorganize language server section for better structure

## Test plan
- [ ] Verify language servers install correctly on NixOS rebuild
- [ ] Test individual language server functionality in Neovim
- [ ] Ensure no conflicts with existing LSP configuration